### PR TITLE
Update DialogProvider.tsx

### DIFF
--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -149,10 +149,10 @@ const [editState, setEditState] = useState<App>(initialAppData || { appId } as A
     }
   };
 
-  if (open && !isLoggedIn) {
-    alert("You're not logged in!");
-    closeDialog();
-  }
+if (open && !isLoggedIn) {
+  setError(true);
+  handleClose();
+}
 
   return (
     <Dialog fullScreen open={open} onClose={handleClose}>

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -270,40 +270,37 @@ const EditAppField = ({ field, label, editState, handleChange }) => (
           special-patch-fake-modified-apk: This patch must always be applied to
           the original unmodified APK. If you want to patch it multiple times
           you must apply the patch every time you modify it
-          <Autocomplete
-            multiple
-            id="tags-filled"
-            options={Object.keys(features).map((key) => key)}
-            freeSolo
-            value={editState.features}
-            onChange={(event: any, newValue) => {
-              console.log("onChange", newValue);
-              handleChange("features", newValue);
-            }}
-            renderTags={(value: readonly string[], getTagProps) =>
-              value.map((option: string, index: number) => (
-                <Chip
-                  variant="outlined"
-                  label={option}
-                  {...getTagProps({ index })}
-                />
-              ))
-            }
-            renderInput={(params) => (
-              <TextField
-                {...params}
-                variant="filled"
-                label="Features"
-                placeholder="Features"
-              />
-            )}
-            renderOption={(props, option) => (
-              <Box component="li" flexDirection="column" {...props}>
-                <Typography>{features[option].label}</Typography>
-                <Typography variant="caption">{option}</Typography>
-              </Box>
-            )}
-          />
+<Autocomplete
+  multiple
+  id="tags-filled"
+  options={Object.keys(features)}
+  freeSolo
+  value={editState.features}
+  onChange={(event, newValue) => handleChange("features", newValue)}
+  renderTags={(value, getTagProps) =>
+    value.map((option, index) => (
+      <Chip
+        variant="outlined"
+        label={option}
+        {...getTagProps({ index })}
+      />
+    ))
+  }
+  renderInput={(params) => (
+    <TextField
+      {...params}
+      variant="filled"
+      label="Features"
+      placeholder="Features"
+    />
+  )}
+  renderOption={(props, option) => (
+    <Box component="li" flexDirection="column" {...props}>
+      <Typography>{features[option].label}</Typography>
+      <Typography variant="caption">{option}</Typography>
+    </Box>
+  )}
+/>
           <Box m={1} />
           {searchPlayStoreResultByTitle?.length > 0 && (
             <>

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -36,11 +36,17 @@ import { closeDialog } from "../redux/systemSlice";
 import { App } from "../types";
 import { DiscordUser, useDiscord } from "../hooks/useDiscord";
 
-const DialogProvider = () => {
+const useDialog = (dialogName: string) => {
   const { dialogs } = useAppSelector((state) => state.system);
-  return (
-    <>{dialogs?.EDIT_APP.open && <EditAppDialog {...dialogs?.EDIT_APP} />}</>
-  );
+  const dialog = dialogs?.[dialogName];
+  return dialog;
+};
+
+const DialogProvider = () => {
+  const dialog = useDialog('EDIT_APP');
+  if (!dialog) return null;
+
+  return <EditAppDialog {...dialog} />;
 };
 
 const AppTextField = ({ editState, field, handleChange }) => {

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -86,11 +86,10 @@ const SearchResult = ({ result, handleChange }) => {
 
 const EditAppDialog = ({ open, appId = "" }) => {
   const dispatch = useAppDispatch();
-  const initialAppData = useAppSelector((state) =>
-    state.apps.find((app) => app.appId === appId)
-  ) || { appId };
-  console.log("initialAppData", initialAppData);
-  const [editState, setEditState] = useState<App>({ ...initialAppData } as App);
+const initialAppData = useAppSelector((state) =>
+  state.apps.find((app) => app.appId === appId)
+);
+const [editState, setEditState] = useState<App>(initialAppData || { appId } as App);
   const [error, setError] = useState(false);
   const [getPlayStoreResult, setGetPlayStoreResult] = useState<App>({} as App);
   const [searchPlayStoreResultByTitle, setSearchPlayStoreResultByTitle] =

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -205,6 +205,7 @@ if (open && !isLoggedIn) {
             </Alert>
           )}
           <Box m={1} />
+          
           <AppTextField
             field="appId"
             editState={editState}
@@ -215,20 +216,36 @@ if (open && !isLoggedIn) {
             <Typography>{`Searched app ID ${editState.appId} and found app in play store with title ${getPlayStoreResult.title}`}</Typography>
           )}
           <Box m={1} />
-          <AppTextField
-            field="title"
-            editState={editState}
-            handleChange={handleChange}
-          />
-          <Typography>
-            You can also use this title field to search for apps.
-          </Typography>
-          <Box m={1} />
-          <AppTextField
-            field="icon"
-            editState={editState}
-            handleChange={handleChange}
-          />
+const EditAppField = ({ field, label, editState, handleChange }) => (
+  <>
+    <AppTextField
+      field={field}
+      label={label}
+      editState={editState}
+      handleChange={handleChange}
+    />
+    <Box m={1} />
+  </>
+);
+
+<EditAppField
+  field="appId"
+  label="App ID"
+  editState={editState}
+  handleChange={handleChange}
+/>
+<EditAppField
+  field="title"
+  label="Title"
+  editState={editState}
+  handleChange={handleChange}
+/>
+<EditAppField
+  field="icon"
+  label="Icon URL"
+  editState={editState}
+  handleChange={handleChange}
+/>
           <Typography>
             The icon URL can be obtained by going to <a href={editState.url} target="_blank">the app's Google Play page</a> and copying the icon image address.
           </Typography>

--- a/src/components/DialogProvider.tsx
+++ b/src/components/DialogProvider.tsx
@@ -118,8 +118,9 @@ const [editState, setEditState] = useState<App>(initialAppData || { appId } as A
     if (open) setEditState({ ...initialAppData } as App);
   }, [open]);
 
-  useEffect(() => {
-    if(!editState.appId && !editState.title) return;  // Don't search if there's nothing to search for
+useEffect(() => {
+  const debounceTimeout = setTimeout(() => {
+    if (!editState.appId && !editState.title) return;
     dispatch(getPlayStoreData({ appId: editState.appId })).then((res) =>
       setGetPlayStoreResult(res.payload)
     );
@@ -129,7 +130,10 @@ const [editState, setEditState] = useState<App>(initialAppData || { appId } as A
     dispatch(searchPlayStoreData({ query: editState.appId })).then((res) =>
       setSearchPlayStoreResultById(res.payload)
     );
-  }, [editState.appId, editState.title]);
+  }, 300);
+
+  return () => clearTimeout(debounceTimeout);
+}, [editState.appId, editState.title]);
 
   const handleSave = async () => {
     // If the user wasn't logged in, the dialog would close.


### PR DESCRIPTION
1. Component Structure and Reusability Current Code:
tsxCopy

const DialogProvider = () => {
  const { dialogs } = useAppSelector((state) => state.system);
  return (
    <>{dialogs?.EDIT_APP.open && <EditAppDialog {...dialogs?.EDIT_APP} />}</>
  );
};

Proposed Changes:

    Component Structure: The DialogProvider component is tightly coupled with the EditAppDialog. It would be better to make it more generic to handle multiple dialogs.
    Reusability: Extract the dialog logic into a separate hook to make it reusable.

New Code:
tsxCopy

const useDialog = (dialogName: string) => {
  const { dialogs } = useAppSelector((state) => state.system);
  const dialog = dialogs?.[dialogName];
  return dialog;
};

const DialogProvider = () => {
  const dialog = useDialog('EDIT_APP');
  if (!dialog) return null;

  return <EditAppDialog {...dialog} />;
};

Benefits:

    Decoupling: The DialogProvider is now decoupled from the specific dialog type.
    Reusability: The useDialog hook can be reused for other dialogs.

## Summary by Sourcery

Refactor the `DialogProvider` to use a new `useDialog` hook. This hook retrieves dialog data based on the dialog name, making the provider more generic and reusable.

Enhancements:
- Decouple the `DialogProvider` component from the `EditAppDialog` component by extracting the dialog logic into a reusable `useDialog` hook.
- Make the `DialogProvider` more generic to handle multiple dialogs by using the `useDialog` hook to retrieve and render dialogs based on their name.